### PR TITLE
Add metrics for detecting missing flows/packets

### DIFF
--- a/utils/metrics.go
+++ b/utils/metrics.go
@@ -103,6 +103,34 @@ var (
 		},
 		[]string{"router", "version", "obs_domain_id", "template_id", "type"}, // options/template
 	)
+	NetFlowFlowsMissing = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "flow_process_nf_flows_missing",
+			Help: "NetFlows missing flows (mostly monotonic, but not always when packets arrive in unordered sequence).",
+		},
+		[]string{"router", "version", "engine_id", "engine_type"},
+	)
+	NetFlowFlowsSequence = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "flow_process_nf_flows_sequence",
+			Help: "NetFlows last sequence number (can be used to detect sequence reset).",
+		},
+		[]string{"router", "version", "engine_id", "engine_type"},
+	)
+	NetFlowPacketsMissing = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "flow_process_nf_packets_missing",
+			Help: "NetFlows missing packets (mostly monotonic, but not always when packets in arrive unordered sequence).",
+		},
+		[]string{"router", "version", "obs_domain_id"},
+	)
+	NetFlowPacketsSequence = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "flow_process_nf_packets_sequence",
+			Help: "NetFlows last sequence number (can be used to detect sequence reset).",
+		},
+		[]string{"router", "version", "obs_domain_id"},
+	)
 	SFlowStats = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "flow_process_sf_count",
@@ -149,6 +177,10 @@ func init() {
 	prometheus.MustRegister(NetFlowSetStatsSum)
 	prometheus.MustRegister(NetFlowTimeStatsSum)
 	prometheus.MustRegister(NetFlowTemplatesStats)
+	prometheus.MustRegister(NetFlowFlowsMissing)
+	prometheus.MustRegister(NetFlowFlowsSequence)
+	prometheus.MustRegister(NetFlowPacketsMissing)
+	prometheus.MustRegister(NetFlowPacketsSequence)
 
 	prometheus.MustRegister(SFlowStats)
 	prometheus.MustRegister(SFlowErrors)

--- a/utils/missingflowstracker.go
+++ b/utils/missingflowstracker.go
@@ -6,7 +6,7 @@ import (
 
 // MissingFlowsTracker is used to track missing packets/flows
 type MissingFlowsTracker struct {
-	counters   map[string]int64 // map[SOURCE_ADDR_DOMAIN_KEY]ACTUAL_FLOWS/PACKET_COUNT
+	counters   map[string]int64 // counter key is based on source addr and sourceId/obsDomain/engineType/engineId
 	countersMu *sync.RWMutex
 
 	maxNegativeSequenceDifference int

--- a/utils/missingflowstracker.go
+++ b/utils/missingflowstracker.go
@@ -1,0 +1,41 @@
+package utils
+
+import (
+	"sync"
+)
+
+// MissingFlowsTracker is used to track missing packets/flows
+type MissingFlowsTracker struct {
+	counters   map[string]int64 // map[SOURCE_ADDR_DOMAIN_KEY]ACTUAL_FLOWS/PACKET_COUNT
+	countersMu *sync.RWMutex
+
+	maxNegativeSequenceDifference int
+}
+
+func NewMissingFlowsTracker(maxNegativeSequenceDifference int) *MissingFlowsTracker {
+	return &MissingFlowsTracker{
+		counters:                      make(map[string]int64),
+		countersMu:                    &sync.RWMutex{},
+		maxNegativeSequenceDifference: maxNegativeSequenceDifference,
+	}
+}
+
+func (s *MissingFlowsTracker) countMissing(key string, seqnum uint32, flows uint16) int64 {
+	s.countersMu.Lock()
+	defer s.countersMu.Unlock()
+
+	if _, ok := s.counters[key]; !ok {
+		s.counters[key] = int64(seqnum)
+	} else {
+		s.counters[key] += int64(flows)
+	}
+	missingElements := int64(seqnum) - s.counters[key]
+
+	// We assume there is a sequence number reset when the number of missing flows/packets is negative and high.
+	// When this happens, we reset the counter to the current sequence number.
+	if missingElements <= -int64(s.maxNegativeSequenceDifference) {
+		s.counters[key] = int64(seqnum)
+		missingElements = 0
+	}
+	return missingElements
+}

--- a/utils/missingflowstracker_test.go
+++ b/utils/missingflowstracker_test.go
@@ -1,0 +1,92 @@
+package utils
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestMissingFlowsTracker_countMissingFlows(t *testing.T) {
+	tests := []struct {
+		name                    string
+		sequenceTrackerKey      string
+		seqnum                  uint32
+		flowCount               uint16
+		savedSeqTracker         map[string]int64
+		expectedMissingFlows    int64
+		expectedSavedSeqTracker map[string]int64
+	}{
+		{
+			name:                 "no saved seq tracker yet",
+			savedSeqTracker:      map[string]int64{},
+			sequenceTrackerKey:   "127.0.01",
+			seqnum:               100,
+			flowCount:            100,
+			expectedMissingFlows: 0,
+			expectedSavedSeqTracker: map[string]int64{
+				"127.0.01": 100,
+			},
+		},
+		{
+			name: "no missing flows",
+			savedSeqTracker: map[string]int64{
+				"127.0.01": 100,
+			},
+			sequenceTrackerKey:   "127.0.01",
+			seqnum:               200,
+			flowCount:            100,
+			expectedMissingFlows: 0,
+			expectedSavedSeqTracker: map[string]int64{
+				"127.0.01": 200,
+			},
+		},
+		{
+			name: "have missing flows",
+			savedSeqTracker: map[string]int64{
+				"127.0.01": 100,
+			},
+			sequenceTrackerKey:   "127.0.01",
+			seqnum:               200,
+			flowCount:            30,
+			expectedMissingFlows: 70,
+			expectedSavedSeqTracker: map[string]int64{
+				"127.0.01": 130,
+			},
+		},
+		{
+			name: "negative saved sequence tracker",
+			// reported missing flows count can be temporarily negative when udp packet arrive unordered,
+			// when slightly lower sequence number arrives after higher sequence number.
+			savedSeqTracker: map[string]int64{
+				"127.0.01": 1000,
+			},
+			sequenceTrackerKey:   "127.0.01",
+			seqnum:               950,
+			flowCount:            10,
+			expectedMissingFlows: -60,
+			expectedSavedSeqTracker: map[string]int64{
+				"127.0.01": 1010,
+			},
+		},
+		{
+			name: "sequence number reset",
+			savedSeqTracker: map[string]int64{
+				"127.0.01": 9000,
+			},
+			sequenceTrackerKey:   "127.0.01",
+			seqnum:               2000,
+			flowCount:            100,
+			expectedMissingFlows: 0,
+			expectedSavedSeqTracker: map[string]int64{
+				"127.0.01": 2000,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewMissingFlowsTracker(1000)
+			s.counters = tt.savedSeqTracker
+			assert.Equal(t, tt.expectedMissingFlows, s.countMissing(tt.sequenceTrackerKey, tt.seqnum, tt.flowCount))
+			assert.Equal(t, tt.expectedSavedSeqTracker, s.counters)
+		})
+	}
+}

--- a/utils/netflow.go
+++ b/utils/netflow.go
@@ -223,8 +223,8 @@ func (s *StateNetFlow) DecodeFlow(msg interface{}) error {
 				Observe(float64(timeDiff))
 		}
 		obsDomainId := strconv.Itoa(int(msgDecConv.SourceId))
-		missingFlowsTrackerKey := key + "|" + obsDomainId
-		missingFlows := s.missingFlowsTracker.countMissing(missingFlowsTrackerKey, msgDecConv.SequenceNumber, 1)
+		missingFlowsKey := key + "|" + obsDomainId
+		missingFlows := s.missingFlowsTracker.countMissing(missingFlowsKey, msgDecConv.SequenceNumber, 1)
 
 		NetFlowPacketsMissing.With(
 			prometheus.Labels{
@@ -335,8 +335,8 @@ func (s *StateNetFlow) DecodeFlow(msg interface{}) error {
 		}
 
 		obsDomainId := strconv.Itoa(int(msgDecConv.ObservationDomainId))
-		missingFlowsTrackerKey := key + "|" + obsDomainId
-		missingFlows := s.missingFlowsTracker.countMissing(missingFlowsTrackerKey, msgDecConv.SequenceNumber, 1)
+		missingFlowsKey := key + "|" + obsDomainId
+		missingFlows := s.missingFlowsTracker.countMissing(missingFlowsKey, msgDecConv.SequenceNumber, 1)
 
 		NetFlowPacketsMissing.With(
 			prometheus.Labels{

--- a/utils/nflegacy.go
+++ b/utils/nflegacy.go
@@ -71,22 +71,25 @@ func (s *StateNFLegacy) DecodeFlow(msg interface{}) error {
 			}).
 			Add(float64(msgDecConv.Count))
 
-		missingFlows := s.missingFlowsTracker.countMissing(key, msgDecConv.FlowSequence, msgDecConv.Count)
+		engineType := strconv.Itoa(int(msgDecConv.EngineType))
+		engineId := strconv.Itoa(int(msgDecConv.EngineId))
+		missingFlowsKey := key + "|" + engineType + "|" + engineId
+		missingFlows := s.missingFlowsTracker.countMissing(missingFlowsKey, msgDecConv.FlowSequence, msgDecConv.Count)
 
 		NetFlowFlowsMissing.With(
 			prometheus.Labels{
 				"router":      key,
 				"version":     "5",
-				"engine_id":   strconv.Itoa(int(msgDecConv.EngineId)),
-				"engine_type": strconv.Itoa(int(msgDecConv.EngineType)),
+				"engine_id":   engineId,
+				"engine_type": engineType,
 			}).
 			Set(float64(missingFlows))
 		NetFlowFlowsSequence.With(
 			prometheus.Labels{
 				"router":      key,
 				"version":     "5",
-				"engine_id":   strconv.Itoa(int(msgDecConv.EngineId)),
-				"engine_type": strconv.Itoa(int(msgDecConv.EngineType)),
+				"engine_id":   engineId,
+				"engine_type": engineType,
 			}).
 			Set(float64(msgDecConv.FlowSequence))
 	}


### PR DESCRIPTION
## What this PR does

Add metrics for detecting missing flows/packets

## Motivation

Detecting missing flows/packets can:
- give visibility on how reliable is the netflow data since high volume of missing flows/packets makes netflow data less reliable
- help sizing (cpu/mem) the netflow collector server, high number of missing flows might mean the server doesn't have enough resources (cpu for example)

## Why not process in later stage of the pipeline (collector, database, etc) ?

It's harder to detect missing flows/packets since not all sequence number are available in later stage of the pipeline. For example:
- Template FlowsSet
- Options Template/Data FlowSet

## Related Issue

https://github.com/netsampler/goflow2/issues/116
